### PR TITLE
Fix compilation on Jazzy

### DIFF
--- a/sdk_core/comm/define.h
+++ b/sdk_core/comm/define.h
@@ -31,7 +31,7 @@
 #include <functional>
 #include <vector>
 #include <atomic>
-#include <stdint.h>
+#include <cinttypes>
 
 #include "livox_lidar_def.h"
 

--- a/sdk_core/comm/define.h
+++ b/sdk_core/comm/define.h
@@ -31,6 +31,7 @@
 #include <functional>
 #include <vector>
 #include <atomic>
+#include <stdint.h>
 
 #include "livox_lidar_def.h"
 

--- a/sdk_core/logger_handler/file_manager.h
+++ b/sdk_core/logger_handler/file_manager.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <stdint.h>
 
 namespace livox {
 namespace lidar {


### PR DESCRIPTION
On modern gcc compilers `stdint.h` is required for types like `uint8_t`.

Is fully backwards compatible with all active ROS distributions.